### PR TITLE
Update wascap dep to support JSON config schemas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provider-archive"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 description = "Library for reading and writing wasmCloud capability provider archive files"
@@ -12,7 +12,7 @@ keywords = ["jwt", "zip", "archive", "security", "wasmcloud"]
 categories = ["cryptography", "authentication", "wasm"]
 
 [dependencies]
-wascap = "0.8.0"
+wascap = "0.11.0"
 data-encoding = "2.3.1"
 ring = "0.16"
 tokio = { version = "1.17.0", features = ["io-util"], default-features = false }

--- a/README.md
+++ b/README.md
@@ -57,4 +57,5 @@ The following is a list of the custom claims that will appear in the `wascap` se
 * `capid` - The capability contract ID (e.g. `wasmcloud:messaging` or `wasmcloud:keyvalue`, etc). Note that the plugin itself is required to expose this information to the runtime when it receives the "query descriptor" message. This value is to allow processes other than the wasmCloud runtime to interrogate the core metadata.
 * `version` - Friendly version string
 * `revision` - A monotonically increasing revision value. This value will be used to retrieve / store version-specific files.
+* `config_schema` - An optional JSON schema that describes the configuration structure for this capability provider. 
 


### PR DESCRIPTION
Quick bump to take new wascap version so that consumers of this crate can use the version of wascap that has support for config JSON schemas.