### PR TITLE
Adding the ability to mutate schema from outside the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provider-archive"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 description = "Library for reading and writing wasmCloud capability provider archive files"
@@ -19,6 +19,7 @@ tokio = { version = "1.17.0", features = ["io-util"], default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["tokio", "gzip"] }
 tokio-tar = "0.3"
 tokio-stream = "0.1"
+serde_json = "1.0"
 
 [dev-dependencies]
 # Turn on the test feature for our tests

--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ The following is a list of the custom claims that will appear in the `wascap` se
 * `revision` - A monotonically increasing revision value. This value will be used to retrieve / store version-specific files.
 * `config_schema` - An optional JSON schema that describes the configuration structure for this capability provider. 
 
+Note that when using this library to create or append to a provider archive the claims for the JWT are _not generated until write-time_ because the hash values for the files are not known until the files are written to the archive. In other words, if you instantiate a `ProviderArchive`, accessing `claims()` will return `None` until after you've called `write`.


### PR DESCRIPTION
The previous version of this crate honored the presence of the config schema in the embedded JWT within the PAR file, but it didn't actually expose a (safe) way of setting that schema when building a provider archive. This fixes that by allowing the schema to be set prior to calling `write`, which generates claims.